### PR TITLE
Skip `cp` warnings when installing fastlane

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,9 @@ FASTLANE_DIR=~/.fastlane/bin
 # Copy fastlane to ~/.fastlane
 echo "Installing fastlane to $FASTLANE_DIR... this might take a few seconds"
 mkdir -p $FASTLANE_DIR
-cp -R "fastlane_lib/" $FASTLANE_DIR
+# We have to skip the 2 error messages below, which are shown if a previous version of fastlane
+# was installed via the bundle
+cp -R "fastlane_lib/" $FASTLANE_DIR 2>&1 | grep -v 'Permission denied' | grep -v 'File exists'
 
 echo "Successfully copied fastlane to $FASTLANE_DIR"
 echo ""


### PR DESCRIPTION
Previously the following was shown

```
cp: /Users/krausefx/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/minitest-5.9.1/test/minitest/test_minitest_spec.rb: Permission denied
cp: /Users/krausefx/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/minitest-5.9.1/test/minitest/test_minitest_test.rb: Permission denied
cp: symlink: bin/xcversion: File exists
```