### PR TITLE
`fastlane update_fastlane` should update all fastlane gems

### DIFF
--- a/shims/fastlane_shim
+++ b/shims/fastlane_shim
@@ -7,7 +7,7 @@ function gem_cleanup() {
 }
 
 if [ "$1" = "update_fastlane" ]; then
-  "${DIR}/bundle/bin/bundle-env" gem update fastlane
+  "${DIR}/bundle/bin/bundle-env" gem update fastlane pilot spaceship produce deliver frameit pem snapshot screengrab supply cert sigh match scan gym fastlane_core credentials_manager
   gem_cleanup
 else
   exec "${DIR}/bundle/bin/bundle-env" fastlane "$@"


### PR DESCRIPTION
I propose this change, to have a faster update cycle. Very often we release a new version of e.g. _deliver_, but don't immediately push a new _fastlane_ release out, so that way the user would get the update available message, and we tell them to run `fastlane update_fastlane`, which would only update _fastlane_ and not _deliver_. 
By adding all tools to this list, the update would be installed for the user 👍