### PR TITLE
Deprecate the tool shims and ask users to execute `fastlane <tool>`

### DIFF
--- a/shims/cert_shim
+++ b/shims/cert_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" cert "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run cert by running `fastlane cert`.'

--- a/shims/deliver_shim
+++ b/shims/deliver_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" deliver "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run deliver by running `fastlane deliver`.'

--- a/shims/fastlane_shim
+++ b/shims/fastlane_shim
@@ -7,7 +7,7 @@ function gem_cleanup() {
 }
 
 if [ "$1" = "update_fastlane" ]; then
-  "${DIR}/bundle/bin/bundle-env" gem update --no-document fastlane pilot spaceship produce deliver frameit pem snapshot screengrab supply cert sigh match scan gym fastlane_core credentials_manager
+  "${DIR}/bundle/bin/bundle-env" gem update --no-document fastlane
   gem_cleanup
 else
   exec "${DIR}/bundle/bin/bundle-env" fastlane "$@"

--- a/shims/frameit_shim
+++ b/shims/frameit_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" frameit "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run frameit by running `fastlane frameit`.'

--- a/shims/gym_shim
+++ b/shims/gym_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" gym "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run gym by running `fastlane gym`.'

--- a/shims/match_shim
+++ b/shims/match_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" match "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run match by running `fastlane match`.'

--- a/shims/pem_shim
+++ b/shims/pem_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" pem "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run pem by running `fastlane pem`.'

--- a/shims/pilot_shim
+++ b/shims/pilot_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" pilot "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run pilot by running `fastlane pilot`.'

--- a/shims/produce_shim
+++ b/shims/produce_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" produce "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run produce by running `fastlane produce`.'

--- a/shims/scan_shim
+++ b/shims/scan_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" scan "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run scan by running `fastlane scan`.'

--- a/shims/screengrab_shim
+++ b/shims/screengrab_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" screengrab "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run screengrab by running `fastlane screengrab`.'

--- a/shims/sigh_shim
+++ b/shims/sigh_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" sigh "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run sigh by running `fastlane sigh`.'

--- a/shims/snapshot_shim
+++ b/shims/snapshot_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" snapshot "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run snapshot by running `fastlane snapshot`.'

--- a/shims/spaceauth_shim
+++ b/shims/spaceauth_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" spaceauth "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run spaceauth by running `fastlane spaceauth`.'

--- a/shims/spaceship_shim
+++ b/shims/spaceship_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" spaceship "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run spaceship by running `fastlane spaceship`.'

--- a/shims/supply_shim
+++ b/shims/supply_shim
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" supply "$@"
+echo 'Executing fastlane tools directly has been deprecated.'
+echo 'Please run supply by running `fastlane supply`.'


### PR DESCRIPTION
This will solve https://github.com/fastlane/fastlane/issues/7656#issuecomment-269241364 and make execution syntax consistent with the gem-installed version.

This PR also stops trying to update all of the gems that no longer exist after the mono-gem work.