### PR TITLE
Restore fastlane command shims

### DIFF
--- a/shims/cert_shim
+++ b/shims/cert_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run cert by running `fastlane cert`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane cert "$@"

--- a/shims/deliver_shim
+++ b/shims/deliver_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run deliver by running `fastlane deliver`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane deliver "$@"

--- a/shims/fastlane-credential_shim
+++ b/shims/fastlane-credential_shim
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-exec "${DIR}/bundle/bin/bundle-env" fastlane-credential "$@"
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane fastlane-credential "$@"

--- a/shims/frameit_shim
+++ b/shims/frameit_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run frameit by running `fastlane frameit`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane frameit "$@"

--- a/shims/gym_shim
+++ b/shims/gym_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run gym by running `fastlane gym`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane gym "$@"

--- a/shims/match_shim
+++ b/shims/match_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run match by running `fastlane match`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane match "$@"

--- a/shims/pem_shim
+++ b/shims/pem_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run pem by running `fastlane pem`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane pem "$@"

--- a/shims/pilot_shim
+++ b/shims/pilot_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run pilot by running `fastlane pilot`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane pilot "$@"

--- a/shims/produce_shim
+++ b/shims/produce_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run produce by running `fastlane produce`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane produce "$@"

--- a/shims/scan_shim
+++ b/shims/scan_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run scan by running `fastlane scan`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane scan "$@"

--- a/shims/screengrab_shim
+++ b/shims/screengrab_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run screengrab by running `fastlane screengrab`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane screengrab "$@"

--- a/shims/sigh_shim
+++ b/shims/sigh_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run sigh by running `fastlane sigh`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane sigh "$@"

--- a/shims/snapshot_shim
+++ b/shims/snapshot_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run snapshot by running `fastlane snapshot`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane snapshot "$@"

--- a/shims/spaceauth_shim
+++ b/shims/spaceauth_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run spaceauth by running `fastlane spaceauth`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane spaceauth "$@"

--- a/shims/spaceship_shim
+++ b/shims/spaceship_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run spaceship by running `fastlane spaceship`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane spaceship "$@"

--- a/shims/supply_shim
+++ b/shims/supply_shim
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo 'Executing fastlane tools directly has been deprecated.'
-echo 'Please run supply by running `fastlane supply`.'
+exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane supply "$@"


### PR DESCRIPTION
&lt;rant&gt;
Pull request #60 (Deprecate the tool shims and ask users to execute `fastlane <tool>`) did not *deprecate* the tool shims, it just broke thousands of scripts relying on running the fastlane tools directly.

What’s the point of providing a shim just to tell the user that they should run the command differently?

I think that every time we (programmers) tell the user what they should do in order to resolve an issue instead of doing it automatically, we have failed. Sometimes we ask the user to do something because doing it programmatically would be a lot of work. For fastlane tools, doing the right thing, the thing that the user expects is literally one line!

```
exec "`dirname "${BASH_SOURCE[0]}"`/bundle/bin/bundle-env" fastlane <tool> "$@"
```

Last year, I started as a .NET developer after 8 years doing iOS development. I had to learn a lot of things, so naturally I read a lot of blog posts and Stack Overflow answers. The most frustrating experience was reading something that I knew would solve my problem but didn’t because the tools or API changed. Please don’t do that with fastlane.
&lt;/rant&gt;