### PR TITLE
handle timeouts and support system http_proxy

### DIFF
--- a/bundle_update_checker.rb
+++ b/bundle_update_checker.rb
@@ -21,9 +21,8 @@ begin
   json_string = resp.body
   json = JSON.parse(json_string)
   available_bundle_version = json['bundle_version']
-  path_to_version = version_file
 
-  version_string = File.open(path_to_version) { |file| file.each_line.first }
+  version_string = File.open(version_file) { |file| file.each_line.first }
   current_bundle_version = version_string.chomp.to_f
 
   if available_bundle_version > current_bundle_version

--- a/bundle_update_checker.rb
+++ b/bundle_update_checker.rb
@@ -1,22 +1,40 @@
 require 'net/http'
 require 'json'
 
-uri = URI('https://kits-crashlytics-com.s3.amazonaws.com/fastlane/standalone/version.json')
-json_string = Net::HTTP.get(uri)
-json = JSON.parse(json_string)
-available_bundle_version = json["bundle_version"]
+begin
+  url = URI.parse('https://kits-crashlytics-com.s3.amazonaws.com/fastlane/standalone/version.json')
+  # Work around ruby defect, where HTTP#get_response and HTTP#post_form
+  # don't use ENV proxy settings
+  # https://bugs.ruby-lang.org/issues/12724
+  http_conn = Net::HTTP.new(url.host, url.port)
+  http_conn.use_ssl = true
+  http_conn.read_timeout = 5
+  http_conn.open_timeout = 5
+  http_conn.ssl_timeout = 5
 
-path_to_version = File.expand_path(File.join(File.dirname(__FILE__), 'VERSION'))
+  resp = http_conn.request_get(url.path)
 
-version_string = File.open(path_to_version) { |file| file.each_line.first }
-current_bundle_version = version_string.chomp.to_f
-
-if available_bundle_version > current_bundle_version
-  puts "fastlane update available"
-  if ENV["FASTLANE_INSTALLED_VIA_HOMEBREW"] == "true"
-    puts "Please run `brew update && brew cask reinstall fastlane`"
-  else
-    puts "Please update fastlane by downloading an updated bundle from"
-    puts "https://download.fastlane.tools"
+  version_file = File.expand_path(File.join(File.dirname(__FILE__), 'VERSION'))
+  unless File.exist?(version_file)
+    raise "Version file not found `#{version_file}`"
   end
+  json_string = resp.body
+  json = JSON.parse(json_string)
+  available_bundle_version = json['bundle_version']
+  path_to_version = version_file
+
+  version_string = File.open(path_to_version) { |file| file.each_line.first }
+  current_bundle_version = version_string.chomp.to_f
+
+  if available_bundle_version > current_bundle_version
+    puts 'fastlane update available'
+    if ENV['FASTLANE_INSTALLED_VIA_HOMEBREW'] == 'true'
+      puts 'Please run `brew update && brew cask reinstall fastlane`'
+    else
+      puts 'Please update fastlane by downloading an updated bundle from'
+      puts 'https://download.fastlane.tools'
+    end
+  end
+rescue => ex
+  puts "fastlane could not check for updates error: #{ex.message}"
 end


### PR DESCRIPTION
supports system http proxy's and sets timeouts, and outputs a notice, but continues to run.

fixes: https://github.com/fastlane/fastlane/issues/7685


for testing set use_ssl=false and run

`ruby bundle_update_checker.rb` -> triggers a timeout

there where similar proxy issues in fastlane solved via -> https://github.com/fastlane/fastlane/pull/6817

a few things changed because i ran rubocop 😢 